### PR TITLE
Fix requirements.txt for Urbansounds 8k example

### DIFF
--- a/urbansounds8k/requirements.txt
+++ b/urbansounds8k/requirements.txt
@@ -5,5 +5,5 @@ pandas>=1.3
 torchvision
 matplotlib
 tqdm
-sklearn
+scikit-learn
 tensorboard


### PR DESCRIPTION
Sklearn is imported as sklearn however, it installed as scikit-learn, for more info see https://pypi.org/project/scikit-learn/